### PR TITLE
fix: SDK init response undefined

### DIFF
--- a/src/SmallcaseGateway.js
+++ b/src/SmallcaseGateway.js
@@ -77,7 +77,7 @@ const setConfigEnvironment = async (envConfig) => {
  */
 const init = async (sdkToken) => {
   const safeToken = typeof sdkToken === "string" ? sdkToken : "";
-  await SmallcaseGatewayNative.init(safeToken);
+  return SmallcaseGatewayNative.init(safeToken);
 };
 
 /**


### PR DESCRIPTION
## FIXED

1. SDK's '_undefined_' response for a successful/errored execution of _init_ method