### PR TITLE
chore: configure npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,17 +2,19 @@ name: publish to npm
 
 on: [workflow_dispatch]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v6
         with:
-          node-version: "14.x"
+          node-version: "25.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Add permissions for OIDC authentication (id-token: write, contents: read)
- Update actions/checkout to v6 and actions/setup-node to v6
- Update Node.js version to 25.x
- Remove NODE_AUTH_TOKEN dependency for trusted publishing